### PR TITLE
item respawn, prevent permanent power up loss, and automated signal connection

### DIFF
--- a/scenes/world_objects/item_acquistion_hitbox.tscn
+++ b/scenes/world_objects/item_acquistion_hitbox.tscn
@@ -7,6 +7,7 @@
 size = Vector2(32, 32)
 
 [node name="Item Acquistion Hitbox" type="Node2D"]
+scale = Vector2(0.486884, 0.486884)
 script = ExtResource("1_t2v86")
 
 [node name="Sprite" type="Sprite2D" parent="."]

--- a/scripts/basic_movement.gd
+++ b/scripts/basic_movement.gd
@@ -102,7 +102,7 @@ func _on_item_acquistion_hitbox_upgrade_collected(upgrade_name, permanent, durat
 	print("PLAYER: Got upgrade " + str(upgrade_name))
 	if upgrades.has(upgrade_name):
 		upgrades[upgrade_name] = true
-		if not permanent:
+		if not permanent and upgrades[upgrade_name] == false:
 			print("will last " + str(duration) + " seconds")
 			await get_tree().create_timer(duration).timeout
 			upgrades[upgrade_name] = false

--- a/scripts/item_acquistion_hitbox.gd
+++ b/scripts/item_acquistion_hitbox.gd
@@ -4,6 +4,7 @@ extends Node2D
 @export_enum("dash", "double_jump") var upgrade_name := ""
 @export var permanent := false
 @export var duration := 10.0
+@export var reappear_time := 0 #time for the time to reappear. If 0, doesn't
 @onready var sprite := $Sprite
 var active := true
 
@@ -16,9 +17,18 @@ signal upgrade_collected(upgrade_name, permanent, duration)
 
 func _ready():
 	sprite.frame = upgrade_sheet[upgrade_name]
+	var player_nodes = get_tree().get_nodes_in_group("Player")
+	
+	for player in player_nodes:
+		upgrade_collected.connect(player._on_item_acquistion_hitbox_upgrade_collected)
 
 func _on_area_2d_body_entered(_body):
+	print(upgrade_name + " collided with player")
 	if active and _body.is_in_group("Player"):
 		active = false
 		upgrade_collected.emit(upgrade_name, permanent, duration)
 		sprite.visible = active
+		if reappear_time > 0 and permanent == false:
+			await get_tree().create_timer(reappear_time).timeout
+			active = true
+			sprite.visible = active


### PR DESCRIPTION
Items can now be set to respawn after being collected if they are temporary, allowing for them to be collected again.

Players no longer lose their power up after the time limit if they collect a temporary variant after already having the permanent one.

Automatically connects the item collection signal to the player because it was annoying to do manually.