### PR TITLE
Added support for permanent upgrades being maintained across levels

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 GameController="*res://scripts/game_controller.gd"
+GPlayerProperties="*res://scripts/player_properties.gd"
 
 [display]
 

--- a/scenes/levels/main.tscn
+++ b/scenes/levels/main.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=16 format=4 uid="uid://bi8dovscytpwf"]
+[gd_scene load_steps=17 format=4 uid="uid://bi8dovscytpwf"]
 
+[ext_resource type="Script" path="res://scripts/scene_logic.gd" id="1_dv2ak"]
 [ext_resource type="PackedScene" uid="uid://beiqcohu2gu4g" path="res://scenes/player.tscn" id="1_ow22n"]
 [ext_resource type="Texture2D" uid="uid://dgrt7meidcjjm" path="res://assets/world_tileset.png" id="2_4uh76"]
 [ext_resource type="Texture2D" uid="uid://dxjei8kqjcq6l" path="res://assets/platforms.png" id="3_hu5p1"]
@@ -192,13 +193,10 @@ _data = {
 }
 
 [node name="World" type="Node2D"]
+script = ExtResource("1_dv2ak")
 
 [node name="Player" parent="." instance=ExtResource("1_ow22n")]
 position = Vector2(474, 559)
-upgrades = {
-"dash": false,
-"double_jump": true
-}
 
 [node name="World Borders" type="Node2D" parent="."]
 
@@ -252,6 +250,7 @@ autoplay = "moving"
 [node name="Item Acquistion Hitbox" parent="." instance=ExtResource("5_6us5t")]
 position = Vector2(770, 464)
 upgrade_name = "double_jump"
+permanent = true
 
 [node name="LevelPortal" parent="." instance=ExtResource("6_er7b2")]
 position = Vector2(276, 599)

--- a/scenes/levels/test_alt_scene.tscn
+++ b/scenes/levels/test_alt_scene.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=8 format=4 uid="uid://cdkcl7te31mff"]
+[gd_scene load_steps=9 format=4 uid="uid://cdkcl7te31mff"]
 
 [ext_resource type="PackedScene" uid="uid://beiqcohu2gu4g" path="res://scenes/player.tscn" id="1_2f0ok"]
+[ext_resource type="Script" path="res://scripts/scene_logic.gd" id="1_ld57w"]
 [ext_resource type="TileSet" uid="uid://bn728p1sy8er7" path="res://assets/forest_tilset.tres" id="2_xqa6n"]
 [ext_resource type="PackedScene" uid="uid://b5dhwryicmp6o" path="res://scenes/world_objects/level_portal.tscn" id="3_ucxot"]
 [ext_resource type="PackedScene" uid="uid://bpknw4f76hnix" path="res://scenes/screens/PauseMenu.tscn" id="4_w25rr"]
@@ -12,6 +13,7 @@ bounce = 0.12
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_0rfj5"]
 
 [node name="World" type="Node2D"]
+script = ExtResource("1_ld57w")
 
 [node name="Player" parent="." instance=ExtResource("1_2f0ok")]
 position = Vector2(43, 607)

--- a/scenes/levels/tileset_test.tscn
+++ b/scenes/levels/tileset_test.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=14 format=4 uid="uid://bi8dovscytpwf"]
+[gd_scene load_steps=15 format=4 uid="uid://bi8dovscytpwf"]
 
 [ext_resource type="Texture2D" uid="uid://brkrc6rs36ouy" path="res://assets/stage_1_forest_v3.png" id="1_gcox3"]
 [ext_resource type="PackedScene" uid="uid://beiqcohu2gu4g" path="res://scenes/player.tscn" id="1_ow22n"]
+[ext_resource type="Script" path="res://scripts/scene_logic.gd" id="1_wpg34"]
 [ext_resource type="Texture2D" uid="uid://1spg1p870bkr" path="res://assets/mr_president.png" id="2_de7ib"]
 [ext_resource type="Texture2D" uid="uid://dxjei8kqjcq6l" path="res://assets/platforms.png" id="3_hu5p1"]
 [ext_resource type="Texture2D" uid="uid://d2xo0fim2hdch" path="res://assets/tree.png" id="3_wyji2"]
@@ -55,6 +56,7 @@ _data = {
 }
 
 [node name="World" type="Node2D"]
+script = ExtResource("1_wpg34")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 modulate = Color(0.65345, 0.657679, 0.675899, 1)

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=54 format=3 uid="uid://beiqcohu2gu4g"]
 
-[ext_resource type="Script" path="res://scripts/basic_movement.gd" id="1_krgb4"]
+[ext_resource type="Script" path="res://scripts/player.gd" id="1_krgb4"]
 [ext_resource type="Texture2D" uid="uid://dp3elhbje8jhq" path="res://assets/player-Sheet.png" id="2_fkr47"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_fgbcy"]

--- a/scripts/level_portal.gd
+++ b/scripts/level_portal.gd
@@ -1,16 +1,21 @@
 extends Area2D
 
-const LEVELPATH = "res://scenes/levels/"
 var levelsuffix = ".tscn"
 
 @export var scenename := ""
+@onready var current_scene = get_tree().get_current_scene()
+
+signal goto_scene(scenename)
 
 func _ready():
+	print(current_scene)
 	if scenename.ends_with(".tscn"):
 		levelsuffix = ""
+	
+	goto_scene.connect(current_scene._loadScene)
 
 func _on_body_entered(body):
 	if body.is_in_group("Player"):
 		print("Player collided with level swapper")
 		print("Changing scene to " + scenename)
-		get_tree().change_scene_to_file.call_deferred(LEVELPATH + scenename + levelsuffix)
+		goto_scene.emit(scenename + levelsuffix)

--- a/scripts/player_properties.gd
+++ b/scripts/player_properties.gd
@@ -1,0 +1,22 @@
+extends Node
+class_name PlayerProperties
+
+var permanent_upgrades := {}
+
+func _init(upgrades = 
+	{"double_jump":false,
+	"dash":false,
+	"wall_cling":false}):
+	for upgrade in upgrades.keys():
+		permanent_upgrades[upgrade] = upgrades[upgrade]
+
+func set_upgrades(upgrades):
+	for upgrade in upgrades.keys():
+		permanent_upgrades[upgrade] = upgrades[upgrade]
+		
+func set_upgrade(upgrade: String, val: bool):
+	permanent_upgrades[upgrade] = val
+
+# Print player properties
+func Print() -> void:
+	print(permanent_upgrades)

--- a/scripts/scene_logic.gd
+++ b/scripts/scene_logic.gd
@@ -1,0 +1,17 @@
+extends Node
+class_name SceneLogic
+
+const LEVELPATH = "res://scenes/levels/"
+
+@onready var m_Player : Player = get_node("Player")
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	m_Player.SetProperties(GPlayerProperties)
+	m_Player.m_Properties.Print()
+
+# Load a scene from a scenename
+func _loadScene(scenename):
+	var playerProperties =  m_Player.GetProperties()
+	GPlayerProperties.set_upgrades(playerProperties.permanent_upgrades)
+	get_tree().change_scene_to_file.call_deferred(LEVELPATH + scenename)


### PR DESCRIPTION
Added a scene management script that should be attached to every new world scene. Added player properties class that can be used to store permanent upgrades. Allows for tracking all this information across levels.

Closes #30.